### PR TITLE
[bug] Absolute pdb path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ optional arguments:
 
 ![](./.github/example.png)
 
+To recursively download the PDBs of all executables in a folder, use:
+
+```
+pdbdownload -d . -S .
+```
+
 ## Contributing
 
 Pull requests are welcome. Feel free to open an issue if you want to add other features.

--- a/pdbdownload/__main__.py
+++ b/pdbdownload/__main__.py
@@ -46,6 +46,9 @@ def get_pe_debug_infos(pathtopefile):
     pdbname: str = raw_debug_data.PdbFileName.strip(b'\x00').decode("utf-8")
     signature: str = p.DIRECTORY_ENTRY_DEBUG[0].entry.Signature_String
 
+    # If an absolute path is embedded the server uses just the filename
+    pdbname = pdbname.split("\\")[-1]
+
     return pdbname, signature
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     author_email="podalirius@protonmail.com",
     packages=["pdbdownload"],
-    package_data={'pdbdownload': ['pdbdownload/']},
+    package_data={'pdbdownload': ['pdbdownload']},
     include_package_data=True,
     license="GPL2",
     classifiers=[


### PR DESCRIPTION
Unfortunately https://github.com/p0dalirius/pdbdownload/pull/5 was clearly never tested, because `get_pe_debug_infos` still returns 3 values, but it's unpacked into 2 values.

This also fixes a bug where a full path to the PDB was being passed to the server. If you have `C:\projects\my.pdb` in the PDB path the symbol server expects you to request `my.pdb`, not the full path.